### PR TITLE
Remove `lodash` to decrease package size

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
-const _ = require('lodash');
 const jsonKeyPathList = require('json-key-path-list');
+
+const Utils = require('./utils.js');
 
 module.exports = {
   jsonDeepDiffList
@@ -8,22 +9,22 @@ module.exports = {
 function jsonDeepDiffList(old, new_) {
   const oldKeyPathList = jsonKeyPathList(old);
   const newKeyPathList = jsonKeyPathList(new_);
-  const intersectionKeyPathList = _.intersection(oldKeyPathList, newKeyPathList);
-  const delKeyPathList = _.difference(oldKeyPathList, intersectionKeyPathList);
-  const addKeyPathList = _.difference(newKeyPathList, intersectionKeyPathList);
+  const intersectionKeyPathList = Utils.intersection(oldKeyPathList, newKeyPathList);
+  const delKeyPathList = Utils.difference(oldKeyPathList, intersectionKeyPathList);
+  const addKeyPathList = Utils.difference(newKeyPathList, intersectionKeyPathList);
   const diffList = [];
 
   intersectionKeyPathList.forEach(path => {
-    const before = _.get(old, path);
-    const after = _.get(new_, path);
+    const before = Utils.get(old, path);
+    const after = Utils.get(new_, path);
     const op = 'replace'
-    if(!_.isEqual(before, after)) {
+    if(!Utils.isEqual(before, after)) {
       diffList.push({ op, path, before, after });
     }
   });
 
   delKeyPathList.forEach(path => {
-    const before = _.get(old, path);
+    const before = Utils.get(old, path);
     const after = undefined;
     const op = 'del';
     diffList.push({ op, path, before, after });
@@ -31,7 +32,7 @@ function jsonDeepDiffList(old, new_) {
 
   addKeyPathList.forEach(path => {
     const before = undefined;
-    const after = _.get(new_, path);
+    const after = Utils.get(new_, path);
     const op = 'add';
     diffList.push({ op, path, before, after });
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -453,11 +453,6 @@
         "p-locate": "^5.0.0"
       }
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "log-symbols": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "mocha": "^8.4.0"
   },
   "dependencies": {
-    "json-key-path-list": "^1.0.0",
-    "lodash": "^4.17.21"
+    "json-key-path-list": "^1.0.0"
   }
 }

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,29 @@
+const isEqual = require('util').isDeepStrictEqual;
+
+function get(obj, path, defValue) {
+	if (!path) {
+		return undefined;
+	}
+	// Check if path is string or array.
+	// Regex matches strings like `a[0].bar.c`
+	const pathArray = Array.isArray(path) ? path : path.match(/([^[.\]])+/g);
+	// Return if exists, otherwise return default value
+	return (
+		pathArray.reduce((prevObj, key) => prevObj && prevObj[key], obj) || defValue
+	);
+}
+
+function difference(arr1, arr2) {
+	return arr1.filter(x => !arr2.includes(x));
+}
+
+function intersection(arr, ...args) {
+	return arr.filter(item => args.every(arr => arr.includes(item)));
+}
+
+module.exports = {
+	difference,
+	get,
+	intersection,
+	isEqual
+};

--- a/utils.js
+++ b/utils.js
@@ -1,29 +1,29 @@
 const isEqual = require('util').isDeepStrictEqual;
 
 function get(obj, path, defValue) {
-	if (!path) {
-		return undefined;
-	}
-	// Check if path is string or array.
-	// Regex matches strings like `a[0].bar.c`
-	const pathArray = Array.isArray(path) ? path : path.match(/([^[.\]])+/g);
-	// Return if exists, otherwise return default value
-	return (
-		pathArray.reduce((prevObj, key) => prevObj && prevObj[key], obj) || defValue
-	);
+  if (!path) {
+    return undefined;
+  }
+  // Check if path is string or array.
+  // Regex matches strings like `a[0].bar.c`
+  const pathArray = Array.isArray(path) ? path : path.match(/([^[.\]])+/g);
+  // Return if exists, otherwise return default value
+  return (
+    pathArray.reduce((prevObj, key) => prevObj && prevObj[key], obj) || defValue
+  );
 }
 
 function difference(arr1, arr2) {
-	return arr1.filter(x => !arr2.includes(x));
+  return arr1.filter(x => !arr2.includes(x));
 }
 
 function intersection(arr, ...args) {
-	return arr.filter(item => args.every(arr => arr.includes(item)));
+  return arr.filter(item => args.every(arr => arr.includes(item)));
 }
 
 module.exports = {
-	difference,
-	get,
-	intersection,
-	isEqual
+  difference,
+  get,
+  intersection,
+  isEqual
 };


### PR DESCRIPTION
Hi there!

I recently found your package on the npm website ( https://www.npmjs.com/package/json-deep-diff-list ) and was surprised by the extremely tight implementation. I was about to use it in my own package, but I saw that `lodash` is in the dependencies, which makes the installed package bloat from 8 KB to 1.36 MB (see https://packagephobia.com/result?p=json-deep-diff-list ).
Since you only use three functions from there, I tried to put them in a separate file which is less than 1 KB. It passes all of the tests, of course.
It would be cool if you accept this request.

Thanks in advance!